### PR TITLE
added flag-mf => fr

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -139,6 +139,7 @@ export const reactionToLang: any = {
   "li": "de",
   "lr": "en",
   "mc": "fr",
+  "mf": "fr",
   "ml": "fr",
   "mp": "en",
   "mq": "fr",


### PR DESCRIPTION
St. Martin island (french half)
slack emoji :flag-mf: is identical to french emoji, thus is often used instead of :flag-fr: