### PR TITLE
preserve Slack message markdown

### DIFF
--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -22,32 +22,61 @@ export class DeepLApi {
       url: "/translate",
       data: qs.stringify({
         auth_key: this.authKey,
+
+        // match special parsing
         text: text.replace(/<(.*?)>/g, function(i: any, match: string) {
-          if(match.match(/^!subteam/)) {
-            return '';
-          }
-          if(match.match(/^!/)) {
-            const matched = match.match(/^!([a-z]+)$/);
+
+          // match #channels and @mentions
+          if(match.match(/^[#@].*$/)) {
+            const matched = match.match(/^([#@].*)$/);
             if (matched != null) {
-              return '<ignore>@' + matched[1] + '</ignore>';
+              return '<mkdwn>' + matched[1] + '</mkdwn>';
             }
             return '';
           }
+
+          // match subteam
+          if(match.match(/^!subteam.*$/)) {
+            return '@[subteam mention removed]';
+          }
+
+          // match date formatting
+          if(match.match(/^!date.*$/)) {
+            const matched = match.match(/^(!date.*)$/);
+            if (matched != null) {
+              return '<mkdwn>' + matched[1] + '</mkdwn>';
+            }
+            return '';
+          }
+
+          // match special mention
+          if(match.match(/^!.*$/)) {
+            const matched = match.match(/^!(.*?)(?:\|.*)?$/);
+            if (matched != null) {
+              return '<ignore>@' + matched[1] + '</ignore>';
+            }
+            return '<ignore>@[special mention]</ignore>';
+          }
+
+          // match formatted link
           if(match.match(/^.*?\|.*$/)) {
             const matched = match.match(/^(.*?)\|(.*)$/);
             if (matched != null) {
               return '<a href="' + matched[1] + '">' + matched[2] + '</a>';
             }
             return '';
-          } else {
-            return '<url>' + match + '</url>';
           }
+
+          // fallback (raw link or unforeseen formatting)
+          return '<mkdwn>' + match + '</mkdwn>';
+
+        // match emoji
         }).replace(/:([a-z0-9_-]+):/g, function(i: any, match: string) {
-           return '<emoji>' + match + '</emoji>';
+          return '<emoji>' + match + '</emoji>';
         }),
         target_lang: targetLanguage.toUpperCase(),
         tag_handling: 'xml',
-        ignore_tags: 'emoji,url,ignore'
+        ignore_tags: 'emoji,mkdwn,ignore'
       }),
       headers: {
         "content-type": "application/x-www-form-urlencoded;charset=utf-8"
@@ -55,16 +84,24 @@ export class DeepLApi {
     }).then(response => {
       this.logger.debug(response.data);
       if (response.data.translations && response.data.translations.length > 0) {
-        return response.data.translations[0].text.replace(/<emoji>(.*?)<\/emoji>/g, function(i: any, match: string) {
+
+        // match emoji
+        return response.data.translations[0].text.replace(/<emoji>([a-z0-9_-]+)<\/emoji>/g, function(i: any, match: string) {
           return ':' + match + ':';
-        }).replace(/<url>(.*?)<\/url>/g, function(i: any, match: string) {
+
+        // match <mkdwn>...</mkdwn>
+        }).replace(/<mkdwn>(.*?)<\/mkdwn>/g, function(i: any, match: string) {
           return '<' + match + '>';
+
+        // match <a href="...">...</a>
         }).replace(/(<a href="(?:.*?)">(?:.*?)<\/a>)/g, function(i: any, match: string) {
           const matched = match.match(/<a href="(.*?)">(.*?)<\/a>/);
           if (matched != null) {
             return '<' + matched[1] + '|' + matched[2] + '>';
           }
           return '';
+
+        // match <ignore>...</ignore>
         }).replace(/<ignore>(.*?)<\/ignore>/g, function(i: any, match: string) {
           return match;
         });

--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -56,18 +56,18 @@ export class DeepLApi {
       this.logger.debug(response.data);
       if (response.data.translations && response.data.translations.length > 0) {
         return response.data.translations[0].text.replace(/<emoji>(.*?)<\/emoji>/g, function(i: any, match: string) {
-      return ':' + match + ':';
-    }).replace(/<url>(.*?)<\/url>/g, function(i: any, match: string) {
-      return '<' + match + '>';
-    }).replace(/(<a href="(?:.*?)">(?:.*?)<\/a>)/g, function(i: any, match: string) {
-      const matched = match.match(/<a href="(.*?)">(.*?)<\/a>/);
-      if (matched != null) {
-        return '<' + matched[1] + '|' + matched[2] + '>';
-      }
-      return '';
-    }).replace(/<ignore>(.*?)<\/ignore>/g, function(i: any, match: string) {
-      return match;
-    });
+          return ':' + match + ':';
+        }).replace(/<url>(.*?)<\/url>/g, function(i: any, match: string) {
+          return '<' + match + '>';
+        }).replace(/(<a href="(?:.*?)">(?:.*?)<\/a>)/g, function(i: any, match: string) {
+          const matched = match.match(/<a href="(.*?)">(.*?)<\/a>/);
+          if (matched != null) {
+            return '<' + matched[1] + '|' + matched[2] + '>';
+          }
+          return '';
+        }).replace(/<ignore>(.*?)<\/ignore>/g, function(i: any, match: string) {
+          return match;
+        });
       } else {
         return ":x: Failed to translate it due to an unexpected response from DeepL API";
       }

--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -30,7 +30,7 @@ export class DeepLApi {
           if(match.match(/^[#@].*$/)) {
             const matched = match.match(/^([#@].*)$/);
             if (matched != null) {
-              return '<mkdwn>' + matched[1] + '</mkdwn>';
+              return '<mrkdwn>' + matched[1] + '</mrkdwn>';
             }
             return '';
           }
@@ -44,7 +44,7 @@ export class DeepLApi {
           if(match.match(/^!date.*$/)) {
             const matched = match.match(/^(!date.*)$/);
             if (matched != null) {
-              return '<mkdwn>' + matched[1] + '</mkdwn>';
+              return '<mrkdwn>' + matched[1] + '</mrkdwn>';
             }
             return '';
           }
@@ -68,7 +68,7 @@ export class DeepLApi {
           }
 
           // fallback (raw link or unforeseen formatting)
-          return '<mkdwn>' + match + '</mkdwn>';
+          return '<mrkdwn>' + match + '</mrkdwn>';
 
         // match emoji
         }).replace(/:([a-z0-9_-]+):/g, function(i: any, match: string) {
@@ -76,7 +76,7 @@ export class DeepLApi {
         }),
         target_lang: targetLanguage.toUpperCase(),
         tag_handling: 'xml',
-        ignore_tags: 'emoji,mkdwn,ignore'
+        ignore_tags: 'emoji,mrkdwn,ignore'
       }),
       headers: {
         "content-type": "application/x-www-form-urlencoded;charset=utf-8"
@@ -89,8 +89,8 @@ export class DeepLApi {
         return response.data.translations[0].text.replace(/<emoji>([a-z0-9_-]+)<\/emoji>/g, function(i: any, match: string) {
           return ':' + match + ':';
 
-        // match <mkdwn>...</mkdwn>
-        }).replace(/<mkdwn>(.*?)<\/mkdwn>/g, function(i: any, match: string) {
+        // match <mrkdwn>...</mrkdwn>
+        }).replace(/<mrkdwn>(.*?)<\/mrkdwn>/g, function(i: any, match: string) {
           return '<' + match + '>';
 
         // match <a href="...">...</a>

--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -36,7 +36,7 @@ export class DeepLApi {
           if(match.match(/^.*?\|.*$/)) {
             const matched = match.match(/^(.*?)\|(.*)$/);
             if (matched != null) {
-              return '<urltext><url>' + matched[1] + '</url>' + matched[2] + '</urltext>';
+              return matched[2] + ' <url>' + matched[1] + '|(link)</url>';
             }
             return '';
           } else {
@@ -57,12 +57,6 @@ export class DeepLApi {
       if (response.data.translations && response.data.translations.length > 0) {
         return response.data.translations[0].text.replace(/<emoji>(.*?)<\/emoji>/g, function(i: any, match: string) {
    return ':' + match + ':';
-}).replace(/(<urltext><url>(?:.*?)<\/url>(?:.*?)<\/urltext>)/g, function(i: any, match: string) {
-  const matched = match.match(/<urltext><url>(.*?)<\/url>(.*)<\/urltext>/);
-  if (matched != null) {
-    return '<' + matched[1] + '|' + matched[2] + '>';
-  }
-  return '';
 }).replace(/<url>(.*?)<\/url>/g, function(i: any, match: string) {
    return '<' + match + '>';
 }).replace(/<ignore>(.*?)<\/ignore>/g, function(i: any, match: string) {

--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -36,7 +36,7 @@ export class DeepLApi {
           if(match.match(/^.*?\|.*$/)) {
             const matched = match.match(/^(.*?)\|(.*)$/);
             if (matched != null) {
-              return matched[2] + ' <url>' + matched[1] + '|(link)</url>';
+              return '<a href="' + matched[1] + '">' + matched[2] + '</a>';
             }
             return '';
           } else {
@@ -56,12 +56,18 @@ export class DeepLApi {
       this.logger.debug(response.data);
       if (response.data.translations && response.data.translations.length > 0) {
         return response.data.translations[0].text.replace(/<emoji>(.*?)<\/emoji>/g, function(i: any, match: string) {
-   return ':' + match + ':';
-}).replace(/<url>(.*?)<\/url>/g, function(i: any, match: string) {
-   return '<' + match + '>';
-}).replace(/<ignore>(.*?)<\/ignore>/g, function(i: any, match: string) {
-   return match;
-});
+      return ':' + match + ':';
+    }).replace(/<url>(.*?)<\/url>/g, function(i: any, match: string) {
+      return '<' + match + '>';
+    }).replace(/(<a href="(?:.*?)">(?:.*?)<\/a>)/g, function(i: any, match: string) {
+      const matched = match.match(/<a href="(.*?)">(.*?)<\/a>/);
+      if (matched != null) {
+        return '<' + matched[1] + '|' + matched[2] + '>';
+      }
+      return '';
+    }).replace(/<ignore>(.*?)<\/ignore>/g, function(i: any, match: string) {
+      return match;
+    });
       } else {
         return ":x: Failed to translate it due to an unexpected response from DeepL API";
       }

--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -22,12 +22,12 @@ export class DeepLApi {
       url: "/translate",
       data: qs.stringify({
         auth_key: this.authKey,
-        text: text.replace(/:([a-z0-9_-]+):/g, function(i, match) {
+        text: text.replace(/:([a-z0-9_-]+):/g, function(i: any, match: string) {
           return '<emoji>' + match + '</emoji>';
         }).replace(/<!subteam\^([A-Za-z0-9]+)>/g, ''),
         target_lang: targetLanguage.toUpperCase(),
-        tag_handling='xml',
-        ignore_tags='emoji'
+        tag_handling: 'xml',
+        ignore_tags: 'emoji'
       }),
       headers: {
         "content-type": "application/x-www-form-urlencoded;charset=utf-8"
@@ -35,9 +35,9 @@ export class DeepLApi {
     }).then(response => {
       this.logger.debug(response.data);
       if (response.data.translations && response.data.translations.length > 0) {
-        return response.data.translations[0].text.replace(/<emoji>([a-z0-9_-]+)<\/emoji>/g, function(i, match) {
+        return response.data.translations[0].text.replace(/<emoji>([a-z0-9_-]+)<\/emoji>/g, function(i: any, match: string) {
           return ':' + match + ':';
-        }).replace(/<!(here|channel|everyone)>/g, function(i, match) {
+        }).replace(/<!(here|channel|everyone)>/g, function(i: any, match: string) {
           return '@' + match;
         });
       } else {

--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -27,12 +27,18 @@ export class DeepLApi {
             return '';
           }
           if(match.match(/^!/)) {
-            let matched = match.match(/^!([a-z]+)$/)[1];
-            return '<ignore>@' + matched + '</ignore>';
+            const matched = match.match(/^!([a-z]+)$/);
+            if (matched != null) {
+              return '<ignore>@' + matched[1] + '</ignore>';
+            }
+            return '';
           }
           if(match.match(/^.*?\|.*$/)) {
-            let matched = match.match(/^(.*?)\|(.*)$/);
-            return '<urltext><url>' + matched[1] + '</url>' + matched[2] + '</urltext>';
+            const matched = match.match(/^(.*?)\|(.*)$/);
+            if (matched != null) {
+              return '<urltext><url>' + matched[1] + '</url>' + matched[2] + '</urltext>';
+            }
+            return '';
           } else {
             return '<url>' + match + '</url>';
           }
@@ -52,8 +58,11 @@ export class DeepLApi {
         return response.data.translations[0].text.replace(/<emoji>(.*?)<\/emoji>/g, function(i: any, match: string) {
    return ':' + match + ':';
 }).replace(/(<urltext><url>(?:.*?)<\/url>(?:.*?)<\/urltext>)/g, function(i: any, match: string) {
-   let matched = match.match(/<urltext><url>(.*?)<\/url>(.*)<\/urltext>/);
-  return '<' + matched[1] + '|' + matched[2] + '>';
+  const matched = match.match(/<urltext><url>(.*?)<\/url>(.*)<\/urltext>/);
+  if (matched != null) {
+    return '<' + matched[1] + '|' + matched[2] + '>';
+  }
+  return '';
 }).replace(/<url>(.*?)<\/url>/g, function(i: any, match: string) {
    return '<' + match + '>';
 }).replace(/<ignore>(.*?)<\/ignore>/g, function(i: any, match: string) {

--- a/src/reacjilator.ts
+++ b/src/reacjilator.ts
@@ -41,6 +41,7 @@ export async function sayInThread(client: WebClient, channel: string, text: stri
   return await client.chat.postMessage({
     channel,
     text,
+    parse: "none",
     thread_ts: message.thread_ts ? message.thread_ts : message.ts
   });
 }


### PR DESCRIPTION
based on https://api.slack.com/reference/surfaces/formatting#retrieving-messages

deepl API ignores content within XML tags emoji, mrkdwn and ignore.

I tested it in my slack workspace, there it works fine. There are still some clashes when bolt/italics/strikethrough formatting is combined with the above ones, but I won't open that can of worms in this pull request.

Also, I can't get `parse: "none"` working (https://api.slack.com/methods/chat.postMessage#formatting).
Imo, Slack shouldn't parse links automatically, because if the bot doesn't receive them formatted, the user removed the link deliberately.

```
Special Parsing
---------------

* Channel:
	<#C024BE7LR>
	=> <mrkdwn>#C024BE7LR</mrkdwn>
	==> <#C024BE7LR>

* User:
	<@U024BE7LH>
	=> <mrkdwn>#C024BE7LR</mrkdwn>
	==> <#C024BE7LR>

* User group:
	<!subteam^SAZ94GDB8>
	=> @[subteam mention removed]
	==> @[subteam mention removed]

* Date:
	<!date^timestamp^token_string^optional_link|fallback_text>
	<!date^1392734382^{date} at {time}|February 18th, 2014 at 6:39 AM PST>
	<!date^1392734382^{date_short}^https://example.com/|Feb 18, 2014 PST>
	=> <mrkdwn>!date^timestamp^token_string^optional_link|fallback_text</mrkdwn>
	==> <!date^timestamp^token_string^optional_link|fallback_text>

* Special mentions:
	<!channel>
	<!here|here>
	=> <ignore>@here</ignore>
	==> @here

* Link:
	<http://example.com|example link>
	<http://example.com>
	=> <a href="http://example.com">example link</a>
	=> <mrkdwn>http://example.com</mrkdwn>
	==> <http://example.com|example link>
	==> <http://example.com>

* Emoji
	:sparkle:
	:flag-fr:
	=> <emoji>sparkle</emoji>
	==> :sparkle:



ENCODE
------

1. /<(.*?)>/g
	Match all special fields

	1.1. /^([#@].*)$/g
		Match #channel and @user mention
		return '<mrkdwn>' + matched[1] + '</mrkdwn>'

	1.2. /^!subteam.*$/g
		Match subteam
		return '@[subteam mention removed]'

	1.3. /^(!date.*)$/g
		Match date
		return '<mrkdwn>' + matched[1] + '</mrkdwn>'

	1.4. /^!(.*?)(?:\|.*)?$/g
		Match special mention
		return <ignore>@match</ignore>

	1.5. /^(.*?)\|(.*)$/g
		Match formatted link
		return '<a href="' + matched[1] + '">' + matched[2] + '</a>'

	1.6. fallback
		Match raw link
		or other unforeseen formattings
		return '<mrkdwn>' + match + '</mrkdwn>'

2. /:([a-z0-9_-]+):/g
	Match all emojis
	return '<emoji>' + match + '</emoji>'



DECODE
------

1. /<emoji>([a-z0-9_-]+)<\/emoji>/g
	Match emojis
	return ':' + match + ':'

2. /<mrkdwn>(.*?)<\/mrkdwn>/g
	Matches all ignored fields
	return '<' + match + '>'

3. /(<a href="(?:.*?)">(?:.*?)<\/a>)/g
	Matches formatted link
	return '<' + matched[1] + '|' + matched[2] + '>'

4. /<ignore>(.*?)<\/ignore>/g
	Matches all ignored fields
	return match
```
